### PR TITLE
Change language around behavior and pull accessibility into TODO

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,13 @@ and will typically contain a message and optionally action and dismiss buttons
 (though arbitrary markup in the element is supported).
 The contents will be announced to a screen reader
 (politely or assertively depending on `type` [see [attributes](#attributes)]),
-and the focusable contents of the toast, if any, will appear next in the tabbing order.
-After a certain duration, the toast will timeout and hide itself,
-though this timeout will be suspended while the toast has focus or the mouse is hovering over it.
+and after a certain duration, the toast will timeout and hide itself
+(though this timeout will be suspended while the toast has focus or the mouse is hovering on it).
+
+TODO([#18](https://github.com/jackbsteinberg/std-toast/issues/18), 
+[#29](https://github.com/jackbsteinberg/std-toast/issues/29)): 
+determine properly accessible behavior,
+specifically w.r.t. actions and navigation to / from the toast.
 
 #### Attributes
 


### PR DESCRIPTION
The behavior section of the explainer makes it come across that we already have accessibility mapped out, while the reality is that we're still considering the best possible solution.

I updated the explainer text to reflect this.